### PR TITLE
Removes space on multiple emails invited

### DIFF
--- a/app/controllers/owner/invitations_controller.rb
+++ b/app/controllers/owner/invitations_controller.rb
@@ -7,9 +7,9 @@ class Owner::InvitationsController < ApplicationController
   def create
     owner = current_user
     vacation = Vacation.find(params[:vacation_id])
-    emails = params[:email_invitations].split(',')
-    email_list = User.check_for_existing_users(owner, emails, vacation.id)
-    email_list.each do |email|
+    emails = params[:email_invitations].split(',').map { |email| email.gsub(" ", "") }
+    non_existing_users = User.check_for_existing_users(owner, emails, vacation.id)
+    non_existing_users.each do |email|
       VacayInviterMailer.invite(owner, email, vacation).deliver_now
     end
     flash[:notice] = 'Successfully sent invitations!'


### PR DESCRIPTION
Closes #87 

Problem: When inviting multiple email address from /owner/vacations/:id/invite, a leading space was getting added to any email address that was not the 1st email. As such, they were not being recognized as existing users in the database, and a VacationUser was not created.

Solution: Added a gsub to replace a space with no space when multiple email addresses are split. Now all existing users have a VacationUser created.