### PR TITLE
Dwolla dropdown

### DIFF
--- a/app/controllers/users/dwollas_controller.rb
+++ b/app/controllers/users/dwollas_controller.rb
@@ -13,12 +13,15 @@ class Users::DwollasController < ApplicationController
   def transfer
     token = dwolla_token
     response = dwolla_transfer(token)
-    #possible model push
     activity = UserActivity.find_by(activity_id: params[:activity_id], user_id: current_user.id)
     activity.update(paid: true)
     activity = Activity.find(params[:activity_id])
     flash[:success] = "You successfully paid for #{activity.name}."
-    redirect_to users_vacation_path(activity.vacation)
+    if vacation_owner?
+      redirect_to owner_vacation_path(activity.vacation)
+    else
+      redirect_to users_vacation_path(activity.vacation)
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,10 @@ class User < ApplicationRecord
     user = User.find_by(email: email)
     VacationUser.create(user_id: user.id, vacation_id: vacay_id)
   end
+
+  def attending?(activity)
+    activity.user_activities.any? do |ua|
+      ua.user_id == self.id
+    end
+  end
 end

--- a/app/views/owner/vacations/show.html.erb
+++ b/app/views/owner/vacations/show.html.erb
@@ -49,6 +49,11 @@
               <% if facade.vacation.users.count > activity.user_activities.count %>
                 <%= link_to "+ Invite All Vacationers", mass_invite_owner_activity_path(activity_id: activity), method: :patch %>
               <% end %>
+              <% if activity.user_id != current_user.id && current_user.attending?(activity) && !facade.paid?(activity, current_user) %>
+                <br /><br />
+                <li>Price Per Person: <%= number_to_currency(facade.user_activity_price(activity, current_user)) %></li>
+                <%= button_to "Settle Up", vacation_dwollas_transfer_path(activity_id: activity.id, vacation_id: facade.vacation_id), class: :button %>
+              <% end %>
           </div>
           <% end %>
         <% end %>

--- a/app/views/users/dwollas/new.html.erb
+++ b/app/views/users/dwollas/new.html.erb
@@ -9,7 +9,17 @@
       <%= text_field_tag :city %></p>
 
       <p><%= label_tag "State" %><br />
-      <%= text_field_tag :state %></p>
+      <p><%= select_tag :state, options_for_select([['Select a State'], ['AL', 'AL'],
+        ['AK', 'AK'], ['AZ', 'AZ'], ['AR', 'AR'], ['CA', 'CA'], ['CO', 'CO'],
+        ['CT', 'CT'], ['DE', 'DE'], ['FL', 'FL'], ['GA', 'GA'], ['HI', 'HI'],
+        ['ID', 'ID'], ['IL', 'IL'], ['IN', 'IN'], ['IA', 'IA'], ['KS', 'KS'],
+        ['KY', 'KY'], ['LA', 'LA'], ['ME', 'ME'], ['MD', 'MD'], ['MA', 'MA'],
+        ['MI', 'MI'], ['MN', 'MN'], ['MS', 'MS'], ['MO', 'MO'], ['MT', 'MT'],
+        ['NE', 'NE'], ['NV', 'NV'], ['NH', 'NH'], ['NJ', 'NJ'], ['NM', 'NM'],
+        ['NY', 'NY'], ['NC', 'NC'], ['ND', 'ND'], ['OH', 'OH'], ['OK', 'OK'],
+        ['OR', 'OR'], ['PA', 'PA'], ['RI', 'RI'], ['SC', 'SC'], ['SD', 'SD'],
+        ['TN', 'TN'], ['TX', 'TX'], ['UT', 'UT'], ['VT', 'VT'], ['VA', 'VA'],
+        ['WA', 'WA'], ['WV', 'WV'], ['WI', 'WI'], ['WY', 'WY']]) %></p>
 
       <p><%= label_tag "Postal Code" %><br />
       <%= text_field_tag :postal_code %></p>


### PR DESCRIPTION
- Updates Dwolla Registration to take a dropdown instead of a textfield for state (prevents users from inputting an unsupported format, ie: colorado, co, etc.)
- Adds the ability for Vacation Owners to pay for an activity that they are attending, but do not own.